### PR TITLE
Upgrade industrial-ui to remove source map warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
       "integrity": "sha512-7vEe8TtOULQWB9HwvUPkrMvMjQAalLo/shSm1ebftjVeeFy61C5+3fUIicYShWw5LRLWzGPtII4lGhMX7xNOug=="
     },
     "@actyx/industrial-ui": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@actyx/industrial-ui/-/industrial-ui-1.0.4.tgz",
-      "integrity": "sha512-FLOMwzNPuo95yMHNaCIfFe4BWUK23DTSMXJmPc5HCbHEF7unzWCPheTLCxAvTiYEUCB80Ts0I0k/V3Qq6BYB8g==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@actyx/industrial-ui/-/industrial-ui-1.0.5.tgz",
+      "integrity": "sha512-/D/oBdTURL0vvU579XAe34sx/h1/kk/k+yrBppPoOu9Bsw2h3uS3yLvdvFvjUZeDBgUldLRnLkw8cOqU0JO3NQ==",
       "requires": {
         "classnames": "^2.2.6",
         "jss": "^10.0.3",
@@ -7527,9 +7527,9 @@
       }
     },
     "react-window": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.5.tgz",
-      "integrity": "sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
+      "integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": ">=3.1.1 <6"
@@ -9273,9 +9273,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-      "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@actyx-contrib/react-pond": "^2.0.0-rc4",
     "@actyx-contrib/rx-pond": "^0.1.0",
-    "@actyx/industrial-ui": "^1.0.4",
+    "@actyx/industrial-ui": "^1.0.5",
     "@actyx/pond": "^2.2.0",
     "netvar": "^1.0.5",
     "react": "^16.13.1",


### PR DESCRIPTION
## PR Description
With https://github.com/Actyx/industrial-ui/pull/158 the missing source maps were added. The fix was released with `industrial-ui 1.0.5`. 

This solves the problem where warnings of the following format were logged for the `dashboard` and `erp-simulator` app.

```
⚠️  Could not load source file "../src/index.ts" in source map of "../../node_modules/@actyx/industrial-ui/lib/index.js".
⚠️  Could not load source file "../../../src/components/Card/index.ts" in source map of "../../node_modules/@actyx/industrial-ui/lib/components/Card/index.js".
⚠️  Could not load source file "../../../src/components/CircularProgress/index.ts" in source map of "../../node_modules/@actyx/industrial-ui/lib/components/CircularProgress/index.js".
```